### PR TITLE
Graylog support only ElasticSearch 2.3

### DIFF
--- a/roles/graylog-appliance/tasks/main.yml
+++ b/roles/graylog-appliance/tasks/main.yml
@@ -4,8 +4,8 @@
     state: present
 
 - apt_repository:
-    repo: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
-    filename: "elastic-5.x"
+    repo: "deb https://artifacts.elastic.co/packages/2.x/apt stable main"
+    filename: "elastic-2.x"
     update_cache: yes
 
 - apt:


### PR DESCRIPTION
Graylog prior to 2.3 does not work with Elasticsearch 5.x!
http://docs.graylog.org/en/2.3/pages/installation.html